### PR TITLE
Omit JavaScript code

### DIFF
--- a/src/main/scala/gitbucket/ipynb/IpynbRenderer.scala
+++ b/src/main/scala/gitbucket/ipynb/IpynbRenderer.scala
@@ -71,9 +71,9 @@ class IpynbRenderer extends Renderer {
                       case _ => ""
                     }
                     s"""<img src="data:$img;base64,$src">"""
-                  case key@("text/plain" | "application/javascript" | _) =>
+                  case key@("application/javascript") => "" // disable Javascript
+                  case key@("text/plain" |  _) =>
                     m(key) match {
-                      // disable Javascript
                       case x: String => HtmlFormat.escape(x)
                       case x: List[_] => x.asInstanceOf[List[String]].map(HtmlFormat.escape).mkString("<br>")
                       case _ => ""


### PR DESCRIPTION
Rendering JavaScript code as plain text makes very ugly view. GitHub seems to omit JavaScript code as follows:

![Rendering ipynb in GitHub](https://user-images.githubusercontent.com/1094760/33358205-7f21d714-d50a-11e7-86b9-3af00ccb7e29.png)

This pull request makes gitbucket-ipynb-plugin become to omit JavaScript code as same as GitHub.

	
